### PR TITLE
Fix a couple of bugs with CAN_BUS_Shield

### DIFF
--- a/CAN_BUS_Shield/mcp_can_dfs.h
+++ b/CAN_BUS_Shield/mcp_can_dfs.h
@@ -255,9 +255,9 @@
 #define MCP_16MHz_200kBPS_CFG2 (0xba)
 #define MCP_16MHz_200kBPS_CFG3 (0x07)
 
-#define MCP_16MHz_125kBPS_CFG1 (0x01)
-#define MCP_16MHz_125kBPS_CFG2 (0xba)
-#define MCP_16MHz_125kBPS_CFG3 (0x07)
+#define MCP_16MHz_125kBPS_CFG1 (0x03)
+#define MCP_16MHz_125kBPS_CFG2 (0xac)
+#define MCP_16MHz_125kBPS_CFG3 (0x03)
 
 #define MCP_16MHz_100kBPS_CFG1 (0x03)
 #define MCP_16MHz_100kBPS_CFG2 (0xba)

--- a/CAN_BUS_Shield/mcp_can_dfs.h
+++ b/CAN_BUS_Shield/mcp_can_dfs.h
@@ -19,7 +19,7 @@
 #ifndef _MCP2515DFS_H_
 #define _MCP2515DFS_H_
 
-#include <arduino.h>
+#include <Arduino.h>
 #include <SPI.h>
 #include <inttypes.h>
 


### PR DESCRIPTION
Hi! Thanks for an excellent library.

This fixes a couple of issues:
- The settings for 125kbaud were incorrect, leading to errors
- arduino.h should be Arduino.h; on case-sensitive filesystems this fails.
